### PR TITLE
Add support for snowmobiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,24 @@ The following permissions come with this plugin's **default configuration**. You
 - `vehiclestorage.modularcarstorage.6rows` -- 6 rows (36 total capacity)
 - `vehiclestorage.modularcarstorage.7rows` -- 7 rows (42 total capacity)
 
+#### Snowmobile
+
+- `vehiclestorage.snowmobile.3rows` -- 3 rows (18 total capacity)
+- `vehiclestorage.snowmobile.4rows` -- 4 rows (24 total capacity)
+- `vehiclestorage.snowmobile.5rows` -- 5 rows (30 total capacity)
+- `vehiclestorage.snowmobile.6rows` -- 6 rows (36 total capacity)
+- `vehiclestorage.snowmobile.7rows` -- 7 rows (42 total capacity)
+- `vehiclestorage.snowmobile.2stashes` -- 7 rows + 2 x 42-slot stash (126 total capacity)
+
+#### Tomaha snowmobile
+
+- `vehiclestorage.tomaha.3rows` -- 3 rows (18 total capacity)
+- `vehiclestorage.tomaha.4rows` -- 4 rows (24 total capacity)
+- `vehiclestorage.tomaha.5rows` -- 5 rows (30 total capacity)
+- `vehiclestorage.tomaha.6rows` -- 6 rows (36 total capacity)
+- `vehiclestorage.tomaha.7rows` -- 7 rows (42 total capacity)
+- `vehiclestorage.tomaha.2stashes` -- 7 rows + 2 x 42-slot stash (126 total capacity)
+
 #### Workcart
 
 - `vehiclestorage.workcart.1box` -- 1 x 42-slot box (42 total capacity)
@@ -894,6 +912,70 @@ Default configuration:
       }
     }
   },
+  "Snowmobile": {
+    "DefaultProfile": {
+      "BuiltInStorageCapacity": 12,
+      "AdditionalStorage": {}
+    },
+    "ProfilesRequiringPermission": [
+      {
+        "PermissionSuffix": "3rows",
+        "BuiltInStorageCapacity": 18
+      },
+      {
+        "PermissionSuffix": "4rows",
+        "BuiltInStorageCapacity": 24
+      },
+      {
+        "PermissionSuffix": "5rows",
+        "BuiltInStorageCapacity": 30
+      },
+      {
+        "PermissionSuffix": "6rows",
+        "BuiltInStorageCapacity": 36
+      },
+      {
+        "PermissionSuffix": "7rows",
+        "BuiltInStorageCapacity": 42
+      },
+      {
+        "PermissionSuffix": "2stashes",
+        "BuiltInStorageCapacity": 42,
+        "AdditionalStorage": {
+          "Back Left Stash": 42,
+          "Back Right Stash": 42
+        }
+      }
+    ],
+    "ContainerPresets": {
+      "Back Left Stash": {
+        "Prefab": "assets/prefabs/deployable/hot air balloon/subents/hab_storage.prefab",
+        "Position": {
+          "x": -0.21,
+          "y": 0.555,
+          "z": -1.08
+        },
+        "RotationAngles": {
+          "x": 0.0,
+          "y": 270.0,
+          "z": 270.0
+        }
+      },
+      "Back Right Stash": {
+        "Prefab": "assets/prefabs/deployable/hot air balloon/subents/hab_storage.prefab",
+        "Position": {
+          "x": 0.21,
+          "y": 0.555,
+          "z": -1.08
+        },
+        "RotationAngles": {
+          "x": 0.0,
+          "y": 90.0,
+          "z": 90.0
+        }
+      }
+    }
+  },
   "SoloSubmarine": {
     "DefaultProfile": {
       "BuiltInStorageCapacity": 18,
@@ -920,12 +1002,12 @@ Default configuration:
         "PermissionSuffix": "1stash",
         "BuiltInStorageCapacity": 42,
         "AdditionalStorage": {
-          "BackLeftStash": 42
+          "Back Left Stash": 42
         }
       }
     ],
     "ContainerPresets": {
-      "BackLeftStash": {
+      "Back Left Stash": {
         "Prefab": "assets/prefabs/deployable/hot air balloon/subents/hab_storage.prefab",
         "Position": {
           "x": -0.34,
@@ -936,6 +1018,70 @@ Default configuration:
           "x": 300.0,
           "y": 270.0,
           "z": 270.0
+        }
+      }
+    }
+  },
+  "Tomaha": {
+    "DefaultProfile": {
+      "BuiltInStorageCapacity": 12,
+      "AdditionalStorage": {}
+    },
+    "ProfilesRequiringPermission": [
+      {
+        "PermissionSuffix": "3rows",
+        "BuiltInStorageCapacity": 18
+      },
+      {
+        "PermissionSuffix": "4rows",
+        "BuiltInStorageCapacity": 24
+      },
+      {
+        "PermissionSuffix": "5rows",
+        "BuiltInStorageCapacity": 30
+      },
+      {
+        "PermissionSuffix": "6rows",
+        "BuiltInStorageCapacity": 36
+      },
+      {
+        "PermissionSuffix": "7rows",
+        "BuiltInStorageCapacity": 42
+      },
+      {
+        "PermissionSuffix": "2stashes",
+        "BuiltInStorageCapacity": 42,
+        "AdditionalStorage": {
+          "Back Left Stash": 42,
+          "Back Right Stash": 42
+        }
+      }
+    ],
+    "ContainerPresets": {
+      "Back Left Stash": {
+        "Prefab": "assets/prefabs/deployable/hot air balloon/subents/hab_storage.prefab",
+        "Position": {
+          "x": -0.21,
+          "y": 0.37,
+          "z": -1.08
+        },
+        "RotationAngles": {
+          "x": 0.0,
+          "y": 270.0,
+          "z": 270.0
+        }
+      },
+      "Back Right Stash": {
+        "Prefab": "assets/prefabs/deployable/hot air balloon/subents/hab_storage.prefab",
+        "Position": {
+          "x": 0.21,
+          "y": 0.37,
+          "z": -1.08
+        },
+        "RotationAngles": {
+          "x": 0.0,
+          "y": 90.0,
+          "z": 90.0
         }
       }
     }

--- a/VehicleStorage.cs
+++ b/VehicleStorage.cs
@@ -12,7 +12,7 @@ using UnityEngine;
 
 namespace Oxide.Plugins
 {
-    [Info("Vehicle Storage", "WhiteThunder", "3.1.1")]
+    [Info("Vehicle Storage", "WhiteThunder", "3.2.0")]
     [Description("Allows adding storage containers to vehicles and increasing built-in storage capacity.")]
     internal class VehicleStorage : CovalencePlugin
     {
@@ -612,6 +612,15 @@ namespace Oxide.Plugins
             public override string PrefabPath => "assets/content/vehicles/sedan_a/sedantest.entity.prefab";
         }
 
+        private class SnowmobileConfig : VehicleConfig
+        {
+            public override string VehicleType => "snowmobile";
+            public override string PrefabPath => "assets/content/vehicles/snowmobiles/snowmobile.prefab";
+
+            public override StorageContainer GetDefaultContainer(BaseEntity entity) =>
+                (entity as Snowmobile)?.GetItemContainer();
+        }
+
         private class SoloSubmarineConfig : VehicleConfig
         {
             public override string VehicleType => "solosub";
@@ -619,6 +628,15 @@ namespace Oxide.Plugins
 
             public override StorageContainer GetDefaultContainer(BaseEntity entity) =>
                 (entity as BaseSubmarine)?.GetItemContainer();
+        }
+
+        private class TomahaConfig : VehicleConfig
+        {
+            public override string VehicleType => "tomaha";
+            public override string PrefabPath => "assets/content/vehicles/snowmobiles/tomahasnowmobile.prefab";
+
+            public override StorageContainer GetDefaultContainer(BaseEntity entity) =>
+                (entity as Snowmobile)?.GetItemContainer();
         }
 
         private class WorkcartConfig : VehicleConfig
@@ -1327,6 +1345,69 @@ namespace Oxide.Plugins
                 },
             };
 
+            [JsonProperty("Snowmobile")]
+            public SnowmobileConfig Snowmobile = new SnowmobileConfig
+            {
+                DefaultProfile = new VehicleProfile
+                {
+                    BuiltInStorageCapacity = 12,
+                    AdditionalStorage = new Dictionary<string, int>(),
+                },
+                ProfilesRequiringPermission = new VehicleProfile[]
+                {
+                    new VehicleProfile
+                    {
+                        PermissionSuffix = "3rows",
+                        BuiltInStorageCapacity = 18,
+                    },
+                    new VehicleProfile
+                    {
+                        PermissionSuffix = "4rows",
+                        BuiltInStorageCapacity = 24,
+                    },
+                    new VehicleProfile
+                    {
+                        PermissionSuffix = "5rows",
+                        BuiltInStorageCapacity = 30,
+                    },
+                    new VehicleProfile
+                    {
+                        PermissionSuffix = "6rows",
+                        BuiltInStorageCapacity = 36,
+                    },
+                    new VehicleProfile
+                    {
+                        PermissionSuffix = "7rows",
+                        BuiltInStorageCapacity = 42,
+                    },
+                    new VehicleProfile
+                    {
+                        PermissionSuffix = "2stashes",
+                        BuiltInStorageCapacity = 42,
+                        AdditionalStorage = new Dictionary<string, int>
+                        {
+                            ["Back Left Stash"] = 42,
+                            ["Back Right Stash"] = 42,
+                        },
+                    },
+                },
+                ContainerPresets = new Dictionary<string, ContainerPreset>
+                {
+                    ["Back Left Stash"] = new ContainerPreset
+                    {
+                        Prefab = HabStoragePrefab,
+                        Position = new Vector3(-0.21f, 0.555f, -1.08f),
+                        RotationAngles = new Vector3(0, 270, 270),
+                    },
+                    ["Back Right Stash"] = new ContainerPreset
+                    {
+                        Prefab = HabStoragePrefab,
+                        Position = new Vector3(0.21f, 0.555f, -1.08f),
+                        RotationAngles = new Vector3(0, 90, 90),
+                    },
+                },
+            };
+
             [JsonProperty("SoloSubmarine")]
             public SoloSubmarineConfig SoloSubmarine = new SoloSubmarineConfig
             {
@@ -1363,17 +1444,80 @@ namespace Oxide.Plugins
                         BuiltInStorageCapacity = 42,
                         AdditionalStorage = new Dictionary<string, int>
                         {
-                            ["BackLeftStash"] = 42,
+                            ["Back Left Stash"] = 42,
                         },
                     },
                 },
                 ContainerPresets = new Dictionary<string, ContainerPreset>
                 {
-                    ["BackLeftStash"] = new ContainerPreset
+                    ["Back Left Stash"] = new ContainerPreset
                     {
                         Prefab = HabStoragePrefab,
                         Position = new Vector3(-0.34f, 1.16f, -0.7f),
                         RotationAngles = new Vector3(300, 270, 270),
+                    },
+                },
+            };
+
+            [JsonProperty("Tomaha")]
+            public TomahaConfig Tomaha = new TomahaConfig
+            {
+                DefaultProfile = new VehicleProfile
+                {
+                    BuiltInStorageCapacity = 12,
+                    AdditionalStorage = new Dictionary<string, int>(),
+                },
+                ProfilesRequiringPermission = new VehicleProfile[]
+                {
+                    new VehicleProfile
+                    {
+                        PermissionSuffix = "3rows",
+                        BuiltInStorageCapacity = 18,
+                    },
+                    new VehicleProfile
+                    {
+                        PermissionSuffix = "4rows",
+                        BuiltInStorageCapacity = 24,
+                    },
+                    new VehicleProfile
+                    {
+                        PermissionSuffix = "5rows",
+                        BuiltInStorageCapacity = 30,
+                    },
+                    new VehicleProfile
+                    {
+                        PermissionSuffix = "6rows",
+                        BuiltInStorageCapacity = 36,
+                    },
+                    new VehicleProfile
+                    {
+                        PermissionSuffix = "7rows",
+                        BuiltInStorageCapacity = 42,
+                    },
+                    new VehicleProfile
+                    {
+                        PermissionSuffix = "2stashes",
+                        BuiltInStorageCapacity = 42,
+                        AdditionalStorage = new Dictionary<string, int>
+                        {
+                            ["Back Left Stash"] = 42,
+                            ["Back Right Stash"] = 42,
+                        },
+                    },
+                },
+                ContainerPresets = new Dictionary<string, ContainerPreset>
+                {
+                    ["Back Left Stash"] = new ContainerPreset
+                    {
+                        Prefab = HabStoragePrefab,
+                        Position = new Vector3(-0.21f, 0.37f, -1.08f),
+                        RotationAngles = new Vector3(0, 270, 270),
+                    },
+                    ["Back Right Stash"] = new ContainerPreset
+                    {
+                        Prefab = HabStoragePrefab,
+                        Position = new Vector3(0.21f, 0.37f, -1.08f),
+                        RotationAngles = new Vector3(0, 90, 90),
                     },
                 },
             };
@@ -1442,7 +1586,9 @@ namespace Oxide.Plugins
                     Rowboat,
                     ScrapTransportHelicopter,
                     Sedan,
+                    Snowmobile,
                     SoloSubmarine,
+                    Tomaha,
                     Workcart,
                 };
 


### PR DESCRIPTION
#### Added support for Snowmobiles

There are now sections of the config called `Snowmobile` and `Tomaha`. The following permissions will be available by default.

Snowmobile:
- `vehiclestorage.snowmobile.3rows` -- 3 rows (18 total capacity)
- `vehiclestorage.snowmobile.4rows` -- 4 rows (24 total capacity)
- `vehiclestorage.snowmobile.5rows` -- 5 rows (30 total capacity)
- `vehiclestorage.snowmobile.6rows` -- 6 rows (36 total capacity)
- `vehiclestorage.snowmobile.7rows` -- 7 rows (42 total capacity)
- `vehiclestorage.snowmobile.2stashes` -- 7 rows + 2 x 42-slot stash (126 total capacity)

Tomaha:
- `vehiclestorage.tomaha.3rows` -- 3 rows (18 total capacity)
- `vehiclestorage.tomaha.4rows` -- 4 rows (24 total capacity)
- `vehiclestorage.tomaha.5rows` -- 5 rows (30 total capacity)
- `vehiclestorage.tomaha.6rows` -- 6 rows (36 total capacity)
- `vehiclestorage.tomaha.7rows` -- 7 rows (42 total capacity)
- `vehiclestorage.tomaha.2stashes` -- 7 rows + 2 x 42-slot stash (126 total capacity)